### PR TITLE
Update Notification to extend craft\base\Model

### DIFF
--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -106,7 +106,7 @@ class Notifications extends Plugin
                         $notification = $notificationSettings['notification'];
 
                         Notifications::$plugin->notificationsService->send(
-                            new $notification($event)
+                            new $notification(['event' => $event])
                         );
                     }
                 }

--- a/src/jobs/SendNotification.php
+++ b/src/jobs/SendNotification.php
@@ -53,7 +53,7 @@ class SendNotification extends BaseJob
         $notification = $this->notificationSettings['notification'];
 
         Notifications::$plugin->notificationsService->send(
-            new $notification($this->event)
+            new $notification(['event' => $this->event])
         );
     }
 

--- a/src/models/Notification.php
+++ b/src/models/Notification.php
@@ -38,6 +38,22 @@ class Notification extends Model
     public $event = null;
 
     /**
+     * Constructor
+     *
+     * @param mixed $config
+     */
+    public function __construct($config)
+    {
+        if ($config instanceof Event) {
+            Craft::$app->getDeprecator()->log('Notification::__construct()', 'Passing a yii\base\Event to Notification::__construct() has been deprecated. Pass a config array with a “event” value instead.');
+
+            $config = ['event' => $config];
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
      * The via function determines which channels will be used to send the notification to.
      * Each channel consists of the name as the key and the receiver(s) as the value in
      * the format that the channel expects.

--- a/src/models/Notification.php
+++ b/src/models/Notification.php
@@ -23,7 +23,7 @@ use yii\base\Event;
  * @package   Notifications
  * @since     1.0.0
  */
-class Notification
+class Notification extends Model
 {
     /**
      * The unique identifier for the notification.
@@ -36,11 +36,6 @@ class Notification
      * @var Event
      */
     public $event = null;
-
-    public function __construct($event = null)
-    {
-        $this->event = $event;
-    }
 
     /**
      * The via function determines which channels will be used to send the notification to.


### PR DESCRIPTION
This makes things cleaner when sending notifications with a config via the service

```php
$notification = new IncomingCall([
    'from' => $from,
    'to' => $to,
]);

Notifications::getInstance()->notificationsService->send($notification);
```

```php
class IncomingCall extends Notification
{
    public $from;
    public $to;

    public function via()
    {
        return [
            'pushover' => PushoverReceiver::withUserKey('xxxx')
                ->toDevice('iphone'),
        ];
    }

    public function toPushover($notifiable)
    {
        return new PushoverMessage("New call from {$this->from}");
    }
}
```